### PR TITLE
feat/hide-incomplete-save-feature-and-update-cypress-testing

### DIFF
--- a/barkend-frontend/cypress/e2e/all-dogs-page.cy.js
+++ b/barkend-frontend/cypress/e2e/all-dogs-page.cy.js
@@ -33,6 +33,8 @@ describe('User flows for all dogs page', () => {
     cy.url().should('eq', 'http://localhost:3000/dog-details/1');
     cy.get('.image-carousel').find('img').first().should('have.attr', 'src', 'https://dl5zpyw5k3jeb.cloudfront.net/photos/pets/70734971/1/?bust=1708020281');
     cy.get('.image-carousel').find('img').last().should('have.attr', 'src', 'https://dl5zpyw5k3jeb.cloudfront.net/photos/pets/70734971/3/?bust=1708020282');
+    cy.get('.swiper-button-next').should('exist')
+    cy.get('.swiper-button-prev').should('exist')
     cy.get('.name').contains(`Hi, I'm Whiskey`);
     cy.get('.sub-details').contains('Adult • Male • Cardigan Welsh Corgi');
     cy.get('ul').contains(`Whiskey's Qualities`);

--- a/barkend-frontend/cypress/e2e/hero-page.cy.js
+++ b/barkend-frontend/cypress/e2e/hero-page.cy.js
@@ -15,10 +15,10 @@ describe('User flows for hero (home) page', () => {
     });
   })
 
-  it('navigates to/from the hero page by all navigation options', () => {
+  it('navigates to/from the hero (home) page by all navigation options', () => {
     cy.get('.get-started-btn').click();
     cy.url().should('eq', 'http://localhost:3000/main');
-    cy.go('back');
+    cy.get('.page-title').click();
     cy.url().should('eq', 'http://localhost:3000/');
     cy.get('.all-dogs-btn').click();
     cy.url().should('eq', 'http://localhost:3000/main');

--- a/barkend-frontend/src/components/DogDetails/DogDetails.css
+++ b/barkend-frontend/src/components/DogDetails/DogDetails.css
@@ -23,6 +23,7 @@ p {
   width: 3%;
   cursor: pointer;
   transition: transform .7s;
+  display: none;
 }
 
 .hrt-btn:hover {

--- a/barkend-frontend/src/components/Header/Header.css
+++ b/barkend-frontend/src/components/Header/Header.css
@@ -38,3 +38,7 @@ a {
   margin: 0;
 }
 
+.saved-dogs-btn {
+  display: none;
+}
+


### PR DESCRIPTION
## Description

This PR:
- hides incomplete dog saving/favoriting feature (to be completed at a later time) from the DOM
- adds cypress testing to check for rendering of carousel next/previous buttons
- adds cypress testing to check navigation to hero page by clicking on "BarkEnd" page title

## What type of PR is this? (check all applicable)

- [x] 💡💫 Feature
- [ ] 🐞🐛 Fix
- [x] 🪸🎭 Refactor
- [ ] 💅🎨 Style
- [ ] 📄💾 Documentation

## Reviewers

Jamie Francisco & Ricky Tran
